### PR TITLE
remove public IP from external selfips

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -181,7 +181,7 @@ module "bigip_1" {
   external_subnet_ids = [
     {
       subnet_id = data.google_compute_subnetwork.external.self_link
-      public_ip = true
+      public_ip = false
       private_ip_primary = "172.16.100.1"
       private_ip_secondary = "172.16.100.128/29"
     },
@@ -224,7 +224,7 @@ module "bigip_2" {
   external_subnet_ids = [
     {
       subnet_id = data.google_compute_subnetwork.external.self_link
-      public_ip = true
+      public_ip = false
       private_ip_primary = "172.16.100.2"
       private_ip_secondary = ""
     },


### PR DESCRIPTION
These are no longer needed now that CFE is in full effect, thanks to Matt Emes.